### PR TITLE
T341789: Add examples to the SDK [Part 4]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,112 @@
 Official WME SDK for Go programming language.
 
 Checkout our [documentation](https://enterprise.wikimedia.com/docs/) and [website](https://enterprise.wikimedia.com/) for more information about the APIs.
+
+## Getting Started
+
+- installing the SDK:
+
+```bash
+go get github.com/wikimedia-enterprise/wme-sdk-go
+```
+
+- expose your credentials (if you don't have credentials already, [sing up](https://dashboard.enterprise.wikimedia.com/signup/)):
+
+```bash
+export WME_USERNAME="...your username...";
+export WME_PASSWORD="...your password...";
+```
+
+- obtain your access token:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/wikimedia-enterprise/wme-sdk-go/pkg/auth"
+)
+
+func main() {
+	ctx := context.Background()
+	ath := auth.NewClient()
+
+	lgn, err := ath.Login(ctx, &auth.LoginRequest{
+		Username: os.Getenv("WME_USERNAME"),
+		Password: os.Getenv("WME_PASSWORD"),
+	})
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	log.Println(lgn.AccessToken)
+}
+```
+
+- putting it all together and making your first API call (we will be querying the Structured Contents endpoint, which is part of the [On-demand API](https://enterprise.wikimedia.com/docs/on-demand/))
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/wikimedia-enterprise/wme-sdk-go/pkg/api"
+	"github.com/wikimedia-enterprise/wme-sdk-go/pkg/auth"
+)
+
+func main() {
+	ctx := context.Background()
+	ath := auth.NewClient()
+
+	lgn, err := ath.Login(ctx, &auth.LoginRequest{
+		Username: os.Getenv("WME_USERNAME"),
+		Password: os.Getenv("WME_PASSWORD"),
+	})
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	defer func() {
+		req := &auth.RevokeTokenRequest{
+			RefreshToken: lgn.RefreshToken,
+		}
+
+		if err := ath.RevokeToken(ctx, req); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	acl := api.NewClient()
+	acl.SetAccessToken(lgn.AccessToken)
+
+	req := &api.Request{
+		Fields: []string{"name", "abstract"},
+		Filters: []*api.Filter{
+			{
+				Field: "in_language.identifier",
+				Value: "en",
+			},
+		},
+	}
+	scs, err := acl.GetStructuredContents(ctx, "Squirrel", req)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	for _, sct := range scs {
+		log.Println(sct.Name)
+		log.Println(sct.Abstract)
+	}
+}
+```
+
+- additional examples, such as connecting to the [streaming API](/example/streaming/), can be found [here](/example/)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Official WME SDK for Go programming language.
 
 Checkout our [documentation](https://enterprise.wikimedia.com/docs/) and [website](https://enterprise.wikimedia.com/) for more information about the APIs.
 
-## Getting Started
+## Getting started
 
 - installing the SDK:
 

--- a/example/login/main.go
+++ b/example/login/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/wikimedia-enterprise/wme-sdk-go/pkg/auth"
+)
+
+func main() {
+	ctx := context.Background()
+	ath := auth.NewClient()
+
+	lgn, err := ath.Login(ctx, &auth.LoginRequest{
+		Username: os.Getenv("WME_USERNAME"),
+		Password: os.Getenv("WME_PASSWORD"),
+	})
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	defer func() {
+		req := &auth.RevokeTokenRequest{
+			RefreshToken: lgn.RefreshToken,
+		}
+
+		if err := ath.RevokeToken(ctx, req); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	// ...your code goes here...
+}

--- a/example/streaming/main.go
+++ b/example/streaming/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/wikimedia-enterprise/wme-sdk-go/pkg/api"
+	"github.com/wikimedia-enterprise/wme-sdk-go/pkg/auth"
+)
+
+func main() {
+	ctx := context.Background()
+	ath := auth.NewClient()
+
+	lgn, err := ath.Login(ctx, &auth.LoginRequest{
+		Username: os.Getenv("WME_USERNAME"),
+		Password: os.Getenv("WME_PASSWORD"),
+	})
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	defer func() {
+		req := &auth.RevokeTokenRequest{
+			RefreshToken: lgn.RefreshToken,
+		}
+
+		if err := ath.RevokeToken(ctx, req); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	acl := api.NewClient()
+	acl.SetAccessToken(lgn.AccessToken)
+
+	cbk := func(art *api.Article) error {
+		log.Println("----------START-----------")
+		log.Printf("name: %s\n", art.Name)
+		log.Printf("abstract: %s\n", art.Abstract)
+		log.Printf("event.identifiers: %s\n", art.Event.Identifier)
+		log.Print("-----------END------------\n\n\n")
+		return nil
+	}
+	req := &api.Request{
+		Fields: []string{"name", "abstract", "event.*"},
+		Filters: []*api.Filter{
+			{
+				Field: "in_language.identifier",
+				Value: "en",
+			},
+		},
+	}
+
+	if err := acl.StreamArticles(ctx, req, cbk); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/example/structured-contents/main.go
+++ b/example/structured-contents/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/wikimedia-enterprise/wme-sdk-go/pkg/api"
+	"github.com/wikimedia-enterprise/wme-sdk-go/pkg/auth"
+)
+
+func main() {
+	ctx := context.Background()
+	ath := auth.NewClient()
+
+	lgn, err := ath.Login(ctx, &auth.LoginRequest{
+		Username: os.Getenv("WME_USERNAME"),
+		Password: os.Getenv("WME_PASSWORD"),
+	})
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	defer func() {
+		req := &auth.RevokeTokenRequest{
+			RefreshToken: lgn.RefreshToken,
+		}
+
+		if err := ath.RevokeToken(ctx, req); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	acl := api.NewClient()
+	acl.SetAccessToken(lgn.AccessToken)
+
+	req := &api.Request{
+		Fields: []string{"name", "abstract"},
+		Filters: []*api.Filter{
+			{
+				Field: "in_language.identifier",
+				Value: "en",
+			},
+		},
+	}
+	scs, err := acl.GetStructuredContents(ctx, "Squirrel", req)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	for _, sct := range scs {
+		log.Println(sct.Name)
+		log.Println(sct.Abstract)
+	}
+}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -168,7 +168,7 @@ func (s *baseEntityTestSuite) SetupSuite() {
 		hdr = func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(s.sts)
 			w.Header().Set("Content-Type", "application/octet-stream")
-			w.Write(dta)
+			_, _ = w.Write(dta)
 		}
 	}
 

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -53,7 +53,7 @@ func (s *endpointTestSuite) SetupSuite() {
 		}
 
 		w.WriteHeader(s.sts)
-		w.Write(dta)
+		_, _ = w.Write(dta)
 	})
 
 	s.srv = httptest.NewServer(rtr)

--- a/test/main.go
+++ b/test/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/wikimedia-enterprise/wme-sdk-go/pkg/api"
+	"github.com/wikimedia-enterprise/wme-sdk-go/pkg/auth"
+)
+
+func main() {
+	ctx := context.Background()
+	ath := auth.NewClient()
+
+	lgn, err := ath.Login(ctx, &auth.LoginRequest{
+		Username: os.Getenv("WME_USERNAME"),
+		Password: os.Getenv("WME_PASSWORD"),
+	})
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	defer func() {
+		req := &auth.RevokeTokenRequest{
+			RefreshToken: lgn.RefreshToken,
+		}
+
+		if err := ath.RevokeToken(ctx, req); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	acl := api.NewClient()
+	acl.SetAccessToken(lgn.AccessToken)
+
+	req := &api.Request{
+		Fields: []string{"name", "abstract"},
+		Filters: []*api.Filter{
+			{
+				Field: "in_language.identifier",
+				Value: "en",
+			},
+		},
+	}
+	scs, err := acl.GetStructuredContents(ctx, "Squirrel", req)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	for _, sct := range scs {
+		log.Println(sct.Name)
+		log.Println(sct.Abstract)
+	}
+}


### PR DESCRIPTION
- added a `LICENSE` file
- expanded `README.md` added `Getting started` section
- added `example` directory for more additional examples